### PR TITLE
This will allow for building fully in docker and not locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,6 @@ ENV PGCOMPARE_HOME=/opt/pgcompare \
     PATH=/opt/pgcompare:$PATH \
     _JAVA_OPTIONS=${JAVA_OPT}
 
-COPY target/ /opt/pgcompare/
-
 CMD ["start.sh"]
 
 WORKDIR "/opt/pgcompare"
@@ -83,8 +81,6 @@ ENV PGCOMPARE_HOME=/opt/pgcompare \
     PGCOMPARE_CONFIG=/etc/pgcompare/pgcompare.properties \
     PATH=/opt/pgcompare:$PATH \
     _JAVA_OPTIONS=${JAVA_OPT}
-
-COPY target/ /opt/pgcompare/
 
 CMD ["start.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN mvn clean install
 
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE} as multi-stage
+ARG JAVA_OPT
 
 RUN microdnf install java-21-openjdk -y
 
@@ -50,7 +51,7 @@ USER 1001
 ENV PGCOMPARE_HOME=/opt/pgcompare \
     PGCOMPARE_CONFIG=/etc/pgcompare/pgcompare.properties \
     PATH=/opt/pgcompare:$PATH \
-    _JAVA_OPTIONS=$JAVA_OPT
+    _JAVA_OPTIONS=${JAVA_OPT}
 
 COPY target/ /opt/pgcompare/
 
@@ -81,7 +82,7 @@ USER 1001
 ENV PGCOMPARE_HOME=/opt/pgcompare \
     PGCOMPARE_CONFIG=/etc/pgcompare/pgcompare.properties \
     PATH=/opt/pgcompare:$PATH \
-    _JAVA_OPTIONS="-XX:UseSVE=0"
+    _JAVA_OPTIONS=${JAVA_OPT}
 
 COPY target/ /opt/pgcompare/
 

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ docker-common:  ##      Build the Docker image
             --label org.opencontainers.image.vendor="Crunchy Data" \
             -t $(CONTAINER):$(IMAGE_TAG) \
             -t $(CONTAINER):$(DATE_TAG) .
-	docker image prune --filter label=stage=featureservbuilder -f
+	docker image prune --filter label=stage=pgcomparebuilder -f
 
 run:  ##                Run the Docker container
 	@echo "Running Docker container..."

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,10 @@ PGCOMPARE_OPTIONS ?= "--batch 0 --project 2"
 
 CONTAINER ?= brianpace/$(PROGRAM)
 DATE ?= $(shell date +%Y%m%d)
-BASE_REGISTRY ?= registry.redhat.io/ubi8
+BASE_REGISTRY ?= registry.access.redhat.com/ubi8
 BASE_IMAGE ?= ubi-minimal
 SYSTEMARCH = $(shell uname -m)
+MAVEN_VER ?= 3.9.9
 
 ifeq ($(SYSTEMARCH), x86_64)
 TARGETARCH ?= amd64
@@ -27,6 +28,7 @@ PLATFORM=amd64
 else
 TARGETARCH ?= arm64
 PLATFORM=arm64
+JAVA_OPT="-XX:UseSVE=0"
 endif
 
 IMAGE_TAG ?= $(APPVERSION)-$(TARGETARCH)
@@ -73,13 +75,15 @@ docker-common:  ##      Build the Docker image
     		--build-arg PLATFORM=$(PLATFORM) \
     		--build-arg TARGETARCH=$(TARGETARCH) \
     		--build-arg VERSION=$(APPVERSION) \
+            --build-arg JAVA_OPT=$(JAVA_OPT) \
+            --build-arg MAVEN_VERSION=$(MAVEN_VER) \
             --label vendor="Crunchy Data" \
             --label url="https://crunchydata.com" \
             --label release="$(APPVERSION)" \
             --label org.opencontainers.image.vendor="Crunchy Data" \
             -t $(CONTAINER):$(IMAGE_TAG) \
             -t $(CONTAINER):$(DATE_TAG) .
-
+	docker image prune --filter label=stage=featureservbuilder -f
 
 run:  ##                Run the Docker container
 	@echo "Running Docker container..."
@@ -118,4 +122,4 @@ help:   ##               Prints this help message
 	@echo ""
 	@echo ""
 
-.PHONY: all build docker run clean status
+.PHONY: all build docker multi-stage-docker run clean status


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
- [X ] Have you added an explanation of what your changes do and why you'd like them to be included?
- [ ] Have you updated or added documentation for the change, as applicable?
- [ X] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Testing enhancement
- [ ] Other

**What is the current behavior (link to any open issues here)?**
Currently you have to build the jar file locally and then copy it into the container, this will use a temporary build container to generate the jar file then copy all the content into the container. This will allow a user to build without needing to install maven or the openjdk in their environment.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


**Other Information**: