### PR TITLE
Add ENUM Data Type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ mvn clean install
 Copy `pgcompare.properties.sample` to `pgcompare.properties` and update the connection parameters for your repository, source, and target databases.
 By default, the application looks for the properties file in the execution directory. Use `PGCOMPARE_CONFIG` environment variable to specify a custom properties file location.
 
-At a minimal the `repo-xxxxx` parameters are required in the properties file (or specified by environment parameters).  Besides the properties file and environment variables, another alternative is to store the property settings in the `dc_project` table.  Settings can be stored in the `project_config` column in JSON format ({"parameter": "value"}).
+At a minimal the `repo-xxxxx` parameters are required in the properties file (or specified by environment parameters).  Besides the properties file and environment variables, another alternative is to store the property settings in the `dc_project` table.  Settings can be stored in the `project_config` column in JSON format ({"parameter": "value"}).  Certain system parameters like log-destination can only be specified via the properties file or environment variables.
 
 ## 4. Initialize Repository
 
@@ -194,7 +194,7 @@ java -jar pgcompare.jar --batch 0 --maponly
 
 ## Properties
 
-Properties are categorized into four sections: system, repository, source, and target. Each section has specific properties, as described in detail in the documentation.  The properties can be specified via a configuration file, environment variables or a combination of both.  To use environment variables, the environment variable will be the name of the property in upper case prefixed with PGCOMPARE-.  For example, batch-fetch-size can be set by using the environment variable PGCOMPARE-BATCH-FETCH-SIZE.
+Properties are categorized into four sections: system, repository, source, and target. Each section has specific properties, as described in detail in the documentation.  The properties can be specified via a configuration file, environment variables or a combination of both.  To use environment variables, the environment variable will be the name of the property in upper case with dashes '-' converted to underscore '_' and prefixed with PGCOMPARE_.  For example, batch-fetch-size can be set by using the environment variable PGCOMPARE_BATCH_FETCH_SIZE.
 
 ### System
 - batch-fetch-size: Sets the fetch size for retrieving rows from the source or target database.

--- a/database/pgCompare.sql
+++ b/database/pgCompare.sql
@@ -73,7 +73,7 @@ CREATE TABLE dc_table_column_map (
 	column_id int8 NOT NULL,
 	column_origin varchar(10) DEFAULT 'source'::character varying NOT NULL,
 	column_name varchar(50) NOT NULL,
-	data_type varchar(30) NOT NULL,
+	data_type text NOT NULL,
 	data_class varchar(20) DEFAULT 'string'::character varying NULL,
 	data_length int4 NULL,
 	number_precision int4 NULL,

--- a/src/main/java/com/crunchydata/controller/ReconcileController.java
+++ b/src/main/java/com/crunchydata/controller/ReconcileController.java
@@ -200,7 +200,7 @@ public class ReconcileController {
 
                     }
 
-                    Logging.write("info", THREAD_NAME, "Waiting for hash threads to complete");
+                    Logging.write("info", THREAD_NAME, "Waiting for compare threads to complete");
                     // Check Threads
                     for (threadReconcile thread : compareList) {
                         thread.join();
@@ -257,7 +257,7 @@ public class ReconcileController {
 
             DecimalFormat formatter = new DecimalFormat("#,###");
 
-            String msgFormat = "Reconciliation Complete: Table = %-30s; Status = %-12s; Equal = %19.19s; Not Equal = %19.19s; Missing Source = %19.19s; Missing Target = %19.19s";
+            String msgFormat = "Reconciliation Complete: Table = %s; Status = %s; Equal = %s; Not Equal = %s; Missing Source = %s; Missing Target = %s";
             Logging.write("info", THREAD_NAME, String.format(msgFormat,dct.getTableAlias(), result.getString("compareStatus"), formatter.format(result.getInt("equal")), formatter.format(result.getInt("notEqual")), formatter.format(result.getInt("missingSource")), formatter.format(result.getInt("missingTarget"))));
 
             result.put("status", "success");

--- a/src/main/java/com/crunchydata/controller/TableController.java
+++ b/src/main/java/com/crunchydata/controller/TableController.java
@@ -159,7 +159,7 @@ public class TableController {
 
                 RepoController.saveTableMap(connRepo, dctm);
 
-                Logging.write("info", THREAD_NAME, String.format("Discovered Table: %s",tableName));
+                Logging.write("info", THREAD_NAME, String.format("Discovered Table (%s): %s",destRole, tableName));
 
             }
         }

--- a/src/main/java/com/crunchydata/pgCompare.java
+++ b/src/main/java/com/crunchydata/pgCompare.java
@@ -56,17 +56,17 @@ public class pgCompare {
 
     public static void main(String[] args) {
 
+        // Command Line Options
+        cmd = parseCommandLine(args);
+        if (cmd == null) return;
+
+        Logging.initialize(Props);
+
         // Catch Shutdown
         Runtime.getRuntime().addShutdownHook(new Thread(() -> Logging.write("info", THREAD_NAME, "Shutting down")));
 
         // Capture the start time for the compare run.
         startStopWatch = System.currentTimeMillis();
-
-        // Command Line Options
-        cmd = parseCommandLine(args);
-        if (cmd == null) return;
-
-        System.out.println(Props.getProperty("log-level"));
 
         // Process Startup
         Logging.write("info", THREAD_NAME,  String.format("Starting - rid: %s", startStopWatch));
@@ -222,7 +222,7 @@ public class pgCompare {
                 dct.setParallelDegree(crsTable.getInt("parallel_degree"));
                 dct.setTableAlias(crsTable.getString("table_alias"));
 
-                Logging.write("info", THREAD_NAME, "Start reconciliation");
+                Logging.write("info", THREAD_NAME, String.format("--- START RECONCILIATION FOR TABLE:  %s ---",dct.getTableAlias().toUpperCase()));
 
                 // Construct DCTableMap Class for Source
                 DCTableMap sourceTableMap = createTableMap("source",dct);

--- a/src/main/java/com/crunchydata/util/ColumnUtility.java
+++ b/src/main/java/com/crunchydata/util/ColumnUtility.java
@@ -63,7 +63,7 @@ public class ColumnUtility {
     /**
      * Array of data types classified as character.
      */
-    public static final String[] charTypes = new String[]{"bpchar", "char", "character", "clob", "json", "jsonb", "nchar", "nclob",
+    public static final String[] charTypes = new String[]{"bpchar", "char", "character", "clob", "enum", "json", "jsonb", "nchar", "nclob",
             "ntext", "nvarchar", "nvarchar2", "text", "varchar", "varchar2", "xml"};
 
     /**
@@ -90,7 +90,7 @@ public class ColumnUtility {
     /**
      * Array of unsupported data types.
      */
-    public static final String[] unsupportedDataTypes = new String[]{"bfile", "bit", "cursor", "enum", "hierarchyid",
+    public static final String[] unsupportedDataTypes = new String[]{"bfile", "bit", "cursor", "hierarchyid",
             "image", "rowid", "rowversion", "set", "sql_variant", "uniqueidentifier", "long", "long raw"};
 
     /**

--- a/src/main/java/com/crunchydata/util/SQLConstantsMYSQL.java
+++ b/src/main/java/com/crunchydata/util/SQLConstantsMYSQL.java
@@ -43,6 +43,7 @@ public interface SQLConstantsMYSQL {
                 SELECT table_schema owner, table_name table_name
                 FROM  information_schema.tables
                 WHERE lower(table_schema)=lower(?)
+                      AND table_type = 'BASE TABLE'
                 ORDER BY table_schema, table_name
                 """;
 

--- a/src/main/java/com/crunchydata/util/SQLConstantsMariaDB.java
+++ b/src/main/java/com/crunchydata/util/SQLConstantsMariaDB.java
@@ -43,6 +43,7 @@ public interface SQLConstantsMariaDB {
                 SELECT table_schema owner, table_name table_name
                 FROM  information_schema.tables
                 WHERE lower(table_schema)=lower(?)
+                      AND table_type = 'BASE TABLE'
                 ORDER BY table_schema, table_name
                 """;
 

--- a/src/main/java/com/crunchydata/util/SQLConstantsRepo.java
+++ b/src/main/java/com/crunchydata/util/SQLConstantsRepo.java
@@ -109,7 +109,7 @@ public interface SQLConstantsRepo {
             	column_id int8 NOT NULL,
             	column_origin varchar(10) DEFAULT 'source'::character varying NOT NULL,
             	column_name varchar(50) NOT NULL,
-            	data_type varchar(30) NOT NULL,
+            	data_type text NOT NULL,
             	data_class varchar(20) DEFAULT 'string'::character varying NULL,
             	data_length int4 NULL,
             	number_precision int4 NULL,

--- a/src/main/java/com/crunchydata/util/Settings.java
+++ b/src/main/java/com/crunchydata/util/Settings.java
@@ -75,6 +75,13 @@ public class Settings {
             }
          }
 
+        // Trim all values in the Properties object
+        configProperties.forEach((key, value) -> {
+            if (value instanceof String) {
+                configProperties.setProperty((String) key, ((String) value).trim());
+            }
+        });
+
         Props = setEnvironment(configProperties);
     }
 
@@ -150,8 +157,8 @@ public class Settings {
     public static Properties setEnvironment (Properties prop) {
 
         System.getenv().forEach((k, v) -> {
-            if (k.contains("PGCOMPARE-")) {
-                prop.setProperty(k.replace("PGCOMPARE-","").toLowerCase(),v);
+            if (k.contains("PGCOMPARE_")) {
+                prop.setProperty(k.replace("PGCOMPARE_","").replace("_","-").toLowerCase(),v);
             }
         });
 

--- a/test/test_db2.sql
+++ b/test/test_db2.sql
@@ -172,3 +172,11 @@ CREATE TABLE pgctest.multipk (
 
 
 INSERT INTO pgctest.multipk ("PK", pk2, "COL_1") VALUES (1, 1, 'test');
+
+
+CREATE TABLE pgctest.plat (
+   id integer NOT NULL,
+   plat varchar(10),
+   CONSTRAINT plat_pk PRIMARY KEY (id));
+
+INSERT INTO pgctest.plat (id, plat) VALUES (1, 'db2');

--- a/test/test_db2.sql
+++ b/test/test_db2.sql
@@ -19,10 +19,10 @@ CREATE TABLE pgctest."Test_Case"
     STATUS CHAR(3),
     SALARY DECIMAL(12,2),
     LAST_LOGIN TIMESTAMP,
-    BIO VARCHAR(2000)
+    BIO VARCHAR(2000),
+    CONSTRAINT test_case_pk PRIMARY KEY (eid)
 );
 
--- Inserting data into Emp table (DB2 uses ISO standard formats for DATE and TIMESTAMP)
 INSERT INTO pgctest."Test_Case" (EID, FIRST_NAME, LAST_NAME, EMAIL, HIRE_DT, AGE, "Zip", STATUS, SALARY, LAST_LOGIN, BIO)
 VALUES (1, 'John', 'Doe', 'john.doe@example.com', '2022-01-15', 30, 90210, 'ACT', 60000.00, '2024-08-20 09:30:00', 'Software Engineer with 5 years of experience.');
 INSERT INTO pgctest."Test_Case" (EID, FIRST_NAME, LAST_NAME, EMAIL, HIRE_DT, AGE, "Zip", STATUS, SALARY, LAST_LOGIN, BIO)
@@ -120,49 +120,7 @@ INSERT INTO pgctest.test_dt VALUES
 (3, DATE'1970-01-03', TIMESTAMP'2030-01-03 01:00:03', TIMESTAMP '2030-01-03 05:00:03', TIMESTAMP'2030-01-03 03:00:03.123456',  TIMESTAMP '2030-01-03 07:00:03.123456'),
 (4, DATE'1970-01-04', TIMESTAMP'2030-01-04 01:00:03', TIMESTAMP '2030-01-04 05:00:03', null                                        ,  null                                                       );
 
--- Creating the test_common table in DB2
-DROP TABLE IF EXISTS pgctest.test_common;
-CREATE TABLE pgctest.test_common
-(
-    id INTEGER NOT NULL PRIMARY KEY,
-    col_small INTEGER,
-    col_int INTEGER,
-    col_bigint BIGINT,
-    col_dec_20 DECIMAL(20),
-    col_dec_38 DECIMAL(31),
-    col_dec_10_2 DECIMAL(10,2),
-    col_float32 FLOAT,
-    col_float64 DOUBLE,
-    col_charnull VARCHAR(30),
-    col_char_2 CHARACTER(2),
-    col_string VARCHAR(4000),
-    col_date DATE,
-    col_datetime TIMESTAMP,
-    col_tstz TIMESTAMP,
-    col_ts6 TIMESTAMP,
-    col_ts6tz TIMESTAMP,
-    col_dec_38_9 DECIMAL(31,9),
-    col_dec_38_30 DECIMAL(31,21)
-);
-
--- Inserting data into test_common
-INSERT INTO pgctest.test_common (id, col_small, col_int, col_bigint, col_dec_20, col_dec_38, col_dec_10_2, col_float32, col_float64, col_charnull, col_char_2, col_string, col_date, col_datetime, col_tstz, col_ts6, col_ts6tz, col_dec_38_9, col_dec_38_30)
-VALUES (1, 1, 1, 1, 12345678901234567890, 1234567890123456789012345, 123.11, 123456.1, 12345678.1, 'abc', 'A ', 'when in the course of human events it becomes necessary...', DATE'1970-01-01', TIMESTAMP'1976-07-04 00:00:01', TIMESTAMP'1976-07-04 00:00:01', TIMESTAMP'1976-07-04 00:00:01.123456', TIMESTAMP'1976-07-04 00:00:01.123456', 123456789012345678901.123456789, 12345678.123456789012345678901);
-INSERT INTO pgctest.test_common (id, col_small, col_int, col_bigint, col_dec_20, col_dec_38, col_dec_10_2, col_float32, col_float64, col_charnull, col_char_2, col_string, col_date, col_datetime, col_tstz, col_ts6, col_ts6tz, col_dec_38_9, col_dec_38_30)
-VALUES (2, 2, 2, 2, 12345678901234567890,1234567890123456789012345,123.22,123456.2,12345678.2,'',   'B' ,'when in the course of human events it becomes necessary...', DATE'1970-01-02', TIMESTAMP'1991-01-02 00:00:02', TIMESTAMP'1991-01-02 00:00:02', TIMESTAMP'1991-01-02 00:00:02.123456',  TIMESTAMP'1991-01-02 00:00:02.123456',223456789012345678901.123456789,22345678.123456789012345678901);
-INSERT INTO pgctest.test_common (id, col_small, col_int, col_bigint, col_dec_20, col_dec_38, col_dec_10_2, col_float32, col_float64, col_charnull, col_char_2, col_string, col_date, col_datetime, col_tstz, col_ts6, col_ts6tz, col_dec_38_9, col_dec_38_30)
-VALUES (3, 3, 3, 3, 12345678901234567890,1234567890123456789012345,123.3, 123456.3,12345678.3,'xyx','C ','when in the course of human events it becomes necessary...', DATE'1970-01-03', TIMESTAMP'2030-01-03 00:00:03', TIMESTAMP'2030-01-03 00:00:03', TIMESTAMP'2030-01-03 00:00:03.123456',  TIMESTAMP'2030-01-03 00:00:03.123456',323456789012345678901.123456789,32345678.123456789012345678901);
-
-DROP IF EXISTS TABLE pgctest.test_hidden;
-CREATE TABLE pgctest.test_hidden  (
-    id INTEGER NOT NULL,
-    hidden_field varchar(20) NOT NULL IMPLICITLY HIDDEN
-);
-
-
-INSERT INTO pgctest.test_hidden (id, hidden_field) VALUES (1, 'brian');
-
-
+DROP TABLE IF EXISTS pgctest.multipk;
 CREATE TABLE pgctest.multipk (
 	"COL_1" varchar(10) NULL,
 	"PK" INTEGER NOT NULL,
@@ -173,10 +131,21 @@ CREATE TABLE pgctest.multipk (
 
 INSERT INTO pgctest.multipk ("PK", pk2, "COL_1") VALUES (1, 1, 'test');
 
-
+DROP TABLE IF EXISTS pgctest.plat;
 CREATE TABLE pgctest.plat (
    id integer NOT NULL,
    plat varchar(10),
    CONSTRAINT plat_pk PRIMARY KEY (id));
 
 INSERT INTO pgctest.plat (id, plat) VALUES (1, 'db2');
+
+-- Test for DB2
+DROP TABLE IF EXISTS pgctest.db2_test_hidden;
+CREATE TABLE pgctest.db2_test_hidden  (
+    id INTEGER NOT NULL,
+    hidden_field varchar(20) NOT NULL IMPLICITLY HIDDEN,
+    CONSTRAINT db2_test_hidden_pk PRIMARY KEY (id)
+);
+
+
+INSERT INTO pgctest.db2_test_hidden (id, hidden_field) VALUES (1, 'brian');

--- a/test/test_mariadb.sql
+++ b/test/test_mariadb.sql
@@ -104,3 +104,10 @@ CREATE TABLE pgctest.multipk (
 
 
 INSERT INTO pgctest.multipk (PK, pk2, COL_1) VALUES (1, 1, 'test');
+
+CREATE TABLE pgctest.plat (
+   id int NOT NULL,
+   plat varchar(10),
+   CONSTRAINT plat_pk PRIMARY KEY (id));
+
+INSERT INTO pgctest.plat (id, plat) VALUES (1, 'mariadb');

--- a/test/test_mariadb.sql
+++ b/test/test_mariadb.sql
@@ -95,6 +95,7 @@ INSERT INTO pgctest.test_dt VALUES
 (3, '1970-01-03', '2030-01-03 01:00:03', convert_tz('2030-01-03 02:00:03','-03:00','UTC'), '2030-01-03 03:00:03.123456',  convert_tz('2030-01-03 04:00:03.123456','-03:00','UTC')),
 (4, '1970-01-04', '2030-01-04 01:00:03', convert_tz('2030-01-04 02:00:03','-03:00','UTC'), null                                        ,  null                    );
 
+DROP TABLE IF EXISTS pgctest.multipk;
 CREATE TABLE pgctest.multipk (
 	COL_1 varchar(10),
 	PK int NOT NULL,
@@ -102,12 +103,21 @@ CREATE TABLE pgctest.multipk (
 	CONSTRAINT multipk_pk PRIMARY KEY (PK, pk2)
 );
 
-
 INSERT INTO pgctest.multipk (PK, pk2, COL_1) VALUES (1, 1, 'test');
 
+DROP TABLE IF EXISTS pgctest.plat;
 CREATE TABLE pgctest.plat (
    id int NOT NULL,
    plat varchar(10),
    CONSTRAINT plat_pk PRIMARY KEY (id));
 
 INSERT INTO pgctest.plat (id, plat) VALUES (1, 'mariadb');
+
+DROP TABLE IF EXISTS pgctest.test_enum;
+CREATE TABLE pgctest.test_enum (
+  id int(11) NOT NULL,
+  status enum('abc','def','ghi'),
+  CONSTRAINT test_enum_pk PRIMARY KEY (id)
+);
+
+INSERT INTO pgctest.test_enum (id, status) values (1, 'abc');

--- a/test/test_mssql.sql
+++ b/test/test_mssql.sql
@@ -103,3 +103,10 @@ CREATE TABLE pgctest.multipk (
 
 
 INSERT INTO pgctest.multipk ("PK", pk2, "COL_1") VALUES (1, 1, 'test');
+
+CREATE TABLE pgctest.plat (
+   id int NOT NULL,
+   plat varchar(10),
+   CONSTRAINT plat_pk PRIMARY KEY (id));
+
+INSERT INTO pgctest.plat (id, plat) VALUES (1, 'mssql');

--- a/test/test_mysql.sql
+++ b/test/test_mysql.sql
@@ -95,6 +95,7 @@ INSERT INTO pgctest.test_dt VALUES
 (3, '1970-01-03', '2030-01-03 01:00:03', '2030-01-03 02:00:03-03:00', '2030-01-03 03:00:03.123456',  '2030-01-03 04:00:03.123456-03:00'),
 (4, '1970-01-04', '2030-01-04 01:00:03', '2030-01-04 02:00:03-03:00', null                                        ,  null                    );
 
+DROP TABLE IF EXISTS pgctest.multipk;
 CREATE TABLE pgctest.multipk (
 	COL_1 varchar(10),
 	PK int NOT NULL,
@@ -105,10 +106,19 @@ CREATE TABLE pgctest.multipk (
 
 INSERT INTO pgctest.multipk (PK, pk2, COL_1) VALUES (1, 1, 'test');
 
-
+DROP TABLE IF EXISTS pgctest.plat;
 CREATE TABLE pgctest.plat (
    id int NOT NULL,
    plat varchar(10),
    CONSTRAINT plat_pk PRIMARY KEY (id));
 
 INSERT INTO pgctest.plat (id, plat) VALUES (1, 'mysql');
+
+DROP TABLE IF EXISTS pgctest.test_enum;
+CREATE TABLE pgctest.test_enum (
+  id int(11) NOT NULL,
+  status enum('abc','def','ghi'),
+  CONSTRAINT test_enum_pk PRIMARY KEY (id)
+);
+
+INSERT INTO pgctest.test_enum (id, status) values (1, 'abc');

--- a/test/test_mysql.sql
+++ b/test/test_mysql.sql
@@ -104,3 +104,11 @@ CREATE TABLE pgctest.multipk (
 
 
 INSERT INTO pgctest.multipk (PK, pk2, COL_1) VALUES (1, 1, 'test');
+
+
+CREATE TABLE pgctest.plat (
+   id int NOT NULL,
+   plat varchar(10),
+   CONSTRAINT plat_pk PRIMARY KEY (id));
+
+INSERT INTO pgctest.plat (id, plat) VALUES (1, 'mysql');

--- a/test/test_ora.sql
+++ b/test/test_ora.sql
@@ -98,3 +98,10 @@ CREATE TABLE pgctest.multipk (
 
 
 INSERT INTO pgctest.multipk ("PK", pk2, "COL_1") VALUES (1, 1, 'test');
+
+CREATE TABLE pgctest.plat (
+   id number(8) NOT NULL,
+   plat varchar2(10),
+   CONSTRAINT plat_pk PRIMARY KEY (id));
+
+INSERT INTO pgctest.plat (id, plat) VALUES (1, 'oracle');

--- a/test/test_pg.sql
+++ b/test/test_pg.sql
@@ -112,3 +112,10 @@ CREATE TABLE pgctest.multipk (
 
 
 INSERT INTO pgctest.multipk ("PK", pk2, "COL_1") VALUES (1, 1, 'test');
+
+CREATE TABLE pgctest.plat (
+   id int NOT NULL,
+   plat varchar(10),
+   CONSTRAINT plat_pk PRIMARY KEY (id));
+
+INSERT INTO pgctest.plat (id, plat) VALUES (1, 'postgres');

--- a/test/test_pg.sql
+++ b/test/test_pg.sql
@@ -104,14 +104,15 @@ INSERT INTO pgctest.test_dt VALUES
 (4, DATE'1970-01-04', TIMESTAMP'2030-01-04 01:00:03', TIMESTAMP WITH TIME ZONE'2030-01-04 02:00:03 -03:00', null                                        ,  null                                                       );
 
 CREATE TABLE pgctest.multipk (
-	"COL_1" varchar(10) NULL,
-	"PK" int4 NOT NULL,
 	pk2 int4 NOT NULL,
-	CONSTRAINT multipk_pk PRIMARY KEY ("PK", pk2)
+	`PK` int4 NOT NULL,
+	`COL_1` varchar(10),
+	CONSTRAINT multipk_pk PRIMARY KEY (`PK`, pk2)
 );
 
 
-INSERT INTO pgctest.multipk ("PK", pk2, "COL_1") VALUES (1, 1, 'test');
+INSERT INTO pgctest.multipk (`PK`, pk2, `COL_1`) VALUES (1, 1, 'test');
+
 
 CREATE TABLE pgctest.plat (
    id int NOT NULL,
@@ -119,3 +120,25 @@ CREATE TABLE pgctest.plat (
    CONSTRAINT plat_pk PRIMARY KEY (id));
 
 INSERT INTO pgctest.plat (id, plat) VALUES (1, 'postgres');
+
+-- Test for Mysql, MariaDB, and Postgres
+CREATE TYPE pgctest.status_enum AS ENUM ('abc', 'def', 'ghi');
+
+CREATE TABLE pgctest.test_enum (
+  id int NOT NULL,
+  status pgctest.status_enum,
+  CONSTRAINT test_enum_pk PRIMARY KEY (id)
+);
+
+INSERT INTO pgctest.test_enum (id, status) VALUES (1, 'abc');
+
+-- Test for DB2
+DROP TABLE IF EXISTS pgctest.db2_test_hidden;
+CREATE TABLE pgctest.db2_test_hidden  (
+    id INTEGER NOT NULL,
+    hidden_field varchar(20),
+    CONSTRAINT db2_test_hidden_pk PRIMARY KEY (id)
+);
+
+
+INSERT INTO pgctest.db2_test_hidden (id, hidden_field) VALUES (1, 'brian');


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
- [x] Have you added an explanation of what your changes do and why you'd like them to be included?
- [x] Have you updated or added documentation for the change, as applicable?
- [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature
- [x] Bug fix
- [x] Documentation
- [x] Testing enhancement
- [x] Other

**What is the current behavior (link to any open issues here)?**

- Added support for ENUM data type for MySQL, MariaDB, and Postgres user defined type.
- Modified environment variables to use underscore instead of dash (updated doc as well).
- Changed data_type column in dc_table_column_map from varchar(30) to text data type to support enum.
- Updated log output messages for additional clarification and formatting.
- Trim all property values.

**What is the new behavior (if this is a feature change)?**
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


**Other Information**: