### PR TITLE
solutions for data comparison between large tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Properties are categorized into four sections: system, repository, source, and t
 
 #### batch-offset-size
   
-  This configuration indicates from which data line the hash value comparison begins to be generated. 
+  This configuration indicates that the first n data entries will be skipped, and the hash values will be generated starting from the (n + 1)th data entry for comparison. 
   
   Default: 0
   
@@ -344,7 +344,7 @@ Properties are categorized into four sections: system, repository, source, and t
   
   Default: 2000
   
-These two configurations are used to paginate the data for querying when generating "hash comparison". For instance, only compare the data ranging from 1000 to 2000 or from 5000 to 10000.
+"batch-offset-size" & "batch-compare-size": These two configurations are used to paginate the data for querying when generating "hash comparison". For instance, only compare the data ranging from 1001 to 2000 or from 5001 to 10000.
 
 #### batch-check-size
   

--- a/README.md
+++ b/README.md
@@ -332,6 +332,26 @@ Properties are categorized into four sections: system, repository, source, and t
   
   Default: 0000000000000000000000.0000000000000000000000
 
+#### batch-offset-size
+  
+  This configuration indicates from which data line the hash value comparison begins to be generated. 
+  
+  batch-offset-size Default: 0
+  
+#### batch-compare-size
+  
+  This configuration indicates how many Hash values will be generated. 
+  
+  Default: 2000
+  
+These two configurations are used to paginate the data for querying when generating "hash comparison". For instance, only compare the data ranging from 1000 to 2000 or from 5000 to 10000.
+
+#### batch-check-size
+  
+  This configuration indicates how many "check validations" are to be performed. 
+  
+  Default: 1000
+
 ### Repository
 
 #### repo-dbname

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Properties are categorized into four sections: system, repository, source, and t
   
   This configuration indicates from which data line the hash value comparison begins to be generated. 
   
-  batch-offset-size Default: 0
+  Default: 0
   
 #### batch-compare-size
   

--- a/pgcompare.properties.sample
+++ b/pgcompare.properties.sample
@@ -58,6 +58,21 @@ log-level = INFO
 # default: true
 database-sort = true
 
+# This configuration indicates that the first n data entries will be skipped, and the hash values will be generated starting from the (n + 1)th data entry for comparison.
+# default: 0
+batch-offset-size = 0
+
+# This configuration indicates how many "hash values" will be generated.
+# default: 2000
+batch-compare-size = 2000
+
+#"batch-offset-size" & "batch-compare-size": These two configurations are used to paginate the data for querying when generating "hash comparison". For instance, only compare the data ranging from 1001 to 2000 or from 5001 to 10000.
+
+# This configuration indicates how many "check validations" are to be performed.
+# default: 1000
+batch-check-size = 1000
+
+
 ##################################
 # repository
 ##################################

--- a/pgcompare.properties.sample
+++ b/pgcompare.properties.sample
@@ -58,15 +58,15 @@ log-level = INFO
 # default: true
 database-sort = true
 
-# This configuration indicates that the first n data entries will be skipped, and the hash values will be generated starting from the (n + 1)th data entry for comparison.
+# This configuration indicates that the hash value will be generated starting from the (n + 1)th data item for comparison..
 # default: 0
-batch-offset-size = 0
+batch-start-size = 0
 
 # This configuration indicates how many "hash values" will be generated.
 # default: 2000
 batch-compare-size = 2000
 
-#"batch-offset-size" & "batch-compare-size": These two configurations are used to paginate the data for querying when generating "hash comparison". For instance, only compare the data ranging from 1001 to 2000 or from 5001 to 10000.
+#"batch-start-size" & "batch-compare-size": These two configurations are used for conducting sample queries on the data, so as to perform the "hash comparison" when generating it. For instance, only the data ranging from 1001 to 2000 or from 5001 to 10000 can be compared.
 
 # This configuration indicates how many "check validations" are to be performed.
 # default: 1000

--- a/src/main/java/com/crunchydata/config/Settings.java
+++ b/src/main/java/com/crunchydata/config/Settings.java
@@ -123,7 +123,7 @@ public class Settings {
         defaultProps.setProperty("observer-vacuum","true");
         defaultProps.setProperty("stage-table-parallel","0");
         defaultProps.setProperty("standard-number-format","0000000000000000000000.0000000000000000000000");
-        defaultProps.setProperty("batch-offset-size","0");
+        defaultProps.setProperty("batch-start-size","0");
         defaultProps.setProperty("batch-compare-size","2000");
         defaultProps.setProperty("batch-check-size","1000");
 

--- a/src/main/java/com/crunchydata/config/Settings.java
+++ b/src/main/java/com/crunchydata/config/Settings.java
@@ -123,6 +123,9 @@ public class Settings {
         defaultProps.setProperty("observer-vacuum","true");
         defaultProps.setProperty("stage-table-parallel","0");
         defaultProps.setProperty("standard-number-format","0000000000000000000000.0000000000000000000000");
+        defaultProps.setProperty("batch-offset-size","0");
+        defaultProps.setProperty("batch-compare-size","2000");
+        defaultProps.setProperty("batch-check-size","1000");
 
 
         // Repository

--- a/src/main/java/com/crunchydata/core/threading/DataComparisonThread.java
+++ b/src/main/java/com/crunchydata/core/threading/DataComparisonThread.java
@@ -82,8 +82,6 @@ public class DataComparisonThread extends Thread {
         int totalRows = 0;
         int reportedRows = 0; // Track rows already reported to database
         int batchCommitSize = Integer.parseInt(Props.getProperty("batch-commit-size"));
-        int batchCommitSize = Integer.parseInt(Props.getProperty("batch-commit-size"));
-        int batchCommitSize = Integer.parseInt(Props.getProperty("batch-commit-size"));
         int fetchSize = Integer.parseInt(Props.getProperty("batch-fetch-size"));
         boolean useLoaderThreads = Integer.parseInt(Props.getProperty("loader-threads")) > 0;
         boolean observerThrottle = Boolean.parseBoolean(Props.getProperty("observer-throttle"));

--- a/src/main/java/com/crunchydata/core/threading/DataComparisonThread.java
+++ b/src/main/java/com/crunchydata/core/threading/DataComparisonThread.java
@@ -29,7 +29,6 @@ import com.crunchydata.model.DataComparisonTable;
 import com.crunchydata.model.DataComparisonTableMap;
 import com.crunchydata.model.DataComparisonResult;
 import com.crunchydata.util.*;
-import org.apache.commons.lang3.StringUtils;
 
 import static com.crunchydata.service.DatabaseConnectionService.getConnection;
 import static com.crunchydata.util.HashingUtils.getMd5;

--- a/src/main/java/com/crunchydata/core/threading/DataComparisonThread.java
+++ b/src/main/java/com/crunchydata/core/threading/DataComparisonThread.java
@@ -136,6 +136,7 @@ public class DataComparisonThread extends Thread {
                         break;
                     case "mysql":
                     case "postgres":
+                    case "snowflake":
                         sql += " LIMIT " + batchCompareSize + " OFFSET " + batchOffsetSize;
                         break;
                     default:

--- a/src/main/java/com/crunchydata/core/threading/DataValidationThread.java
+++ b/src/main/java/com/crunchydata/core/threading/DataValidationThread.java
@@ -35,6 +35,7 @@ import com.crunchydata.service.SQLFixGenerationService;
 import com.crunchydata.util.DataProcessingUtils;
 import com.crunchydata.util.LoggingUtils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -83,9 +84,16 @@ public class DataValidationThread {
 
         PreparedStatement stmt = null;
         ResultSet rs = null;
+        String SQL_REPO_SELECT_OUTOFSYNC_ROWS_LIMIT;
+        String batchCheckSize = Props.getProperty("batch-check-size");
         
         try {
-            stmt = repoConn.prepareStatement(SQL_REPO_SELECT_OUTOFSYNC_ROWS);
+            if (StringUtils.isNotEmpty(batchCheckSize)) {
+                SQL_REPO_SELECT_OUTOFSYNC_ROWS_LIMIT = SQL_REPO_SELECT_OUTOFSYNC_ROWS + " LIMIT " + batchCheckSize;
+                stmt = repoConn.prepareStatement(SQL_REPO_SELECT_OUTOFSYNC_ROWS_LIMIT);
+            } else {
+                stmt = repoConn.prepareStatement(SQL_REPO_SELECT_OUTOFSYNC_ROWS);
+            }
             stmt.setObject(1, dct.getTid());
             stmt.setObject(2, dct.getTid());
             rs = stmt.executeQuery();

--- a/src/main/java/com/crunchydata/core/threading/DataValidationThread.java
+++ b/src/main/java/com/crunchydata/core/threading/DataValidationThread.java
@@ -85,10 +85,10 @@ public class DataValidationThread {
         PreparedStatement stmt = null;
         ResultSet rs = null;
         String SQL_REPO_SELECT_OUTOFSYNC_ROWS_LIMIT;
-        String batchCheckSize = Props.getProperty("batch-check-size");
+        int batchCheckSize = Integer.parseInt(Props.getProperty("batch-check-size"));
         
         try {
-            if (StringUtils.isNotEmpty(batchCheckSize)) {
+            if (batchCheckSize > 0) {
                 SQL_REPO_SELECT_OUTOFSYNC_ROWS_LIMIT = SQL_REPO_SELECT_OUTOFSYNC_ROWS + " LIMIT " + batchCheckSize;
                 stmt = repoConn.prepareStatement(SQL_REPO_SELECT_OUTOFSYNC_ROWS_LIMIT);
             } else {

--- a/src/main/java/com/crunchydata/core/threading/DataValidationThread.java
+++ b/src/main/java/com/crunchydata/core/threading/DataValidationThread.java
@@ -35,7 +35,6 @@ import com.crunchydata.service.SQLFixGenerationService;
 import com.crunchydata.util.DataProcessingUtils;
 import com.crunchydata.util.LoggingUtils;
 
-import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
- [x] Have you added an explanation of what your changes do and why you'd like them to be included?
- [x] Have you updated or added documentation for the change, as applicable?
- [x] Have you tested your changes on all related environments with successful results, as applicable?

**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature
- [ ] Bug fix
- [x] Documentation
- [ ] Testing enhancement
- [ ] Other

**What Happened**

I think if there is too much data, it is not necessary to compare all of it. Because on the one hand, it wastes a lot of time; on the other hand, it is sufficient to just sample and compare a portion of the data. 
"batch-offset-size" & "batch-compare-size"：
These two configurations are used to paginate the data for querying when generating "hash comparison". For instance, only compare the data ranging from 1001 to 2000 or from 5001 to 10000.
"batch-check-size":
This configuration is used for "check verification". During this process, n pre-generated hash values are selected for "check verification". For example, if "compare" generates one billion hash values, and if all these one billion hash values are different, the user doesn't need to check all the verification values. They only need to know that there is a difference. In general, the "batch-check-size" value is less than or equal to the "batch-compare-size" value.




**Other Information**: